### PR TITLE
Fix cmake error introduced when cloning from prometheus-cpp master

### DIFF
--- a/RIC-E2-TERMINATION/Dockerfile
+++ b/RIC-E2-TERMINATION/Dockerfile
@@ -60,7 +60,7 @@ RUN mv /opt/e2/RIC-E2-TERMINATION/CMakeLists.txt /opt/e2/ && cat /opt/e2/RIC-E2-
        --buildtype=release -DPISTACHE_USE_SSL=false -DPISTACHE_BUILD_EXAMPLES=false  -DPISTACHE_BUILD_TESTS=false \
         -DPISTACHE_BUILD_DOCS=false  --prefix=/usr/local \
     && meson compile -C build  && meson install -C build  && ldconfig \
-    && cd /opt/e2/RIC-E2-TERMINATION/3rdparty && git clone -v https://github.com/jupp0r/prometheus-cpp.git \
+    && cd /opt/e2/RIC-E2-TERMINATION/3rdparty && git clone -v https://github.com/jupp0r/prometheus-cpp.git --branch v1.1.0 \
     && cd prometheus-cpp && git submodule init && git submodule update && mkdir build && cd build \
     && cmake .. -DBUILD_SHARED_LIBS=OFF && make -j 4  && make install && ldconfig \
     && cd /opt/e2/RIC-E2-TERMINATION/3rdparty && git clone https://github.com/jarro2783/cxxopts.git \


### PR DESCRIPTION
When following the installation procedures from the docs I endet up with the following error at step 3: Build Modified E2 docker Image.
```
Cloning into 'prometheus-cpp'...
POST git-upload-pack (gzip 3077 to 1558 bytes)
Submodule 'civetweb' (https://github.com/civetweb/civetweb.git) registered for path '3rdparty/civetweb'
Submodule 'googletest' (https://github.com/google/googletest.git) registered for path '3rdparty/googletest'
Cloning into '/opt/e2/RIC-E2-TERMINATION/3rdparty/prometheus-cpp/3rdparty/civetweb'...
Cloning into '/opt/e2/RIC-E2-TERMINATION/3rdparty/prometheus-cpp/3rdparty/googletest'...
Submodule path '3rdparty/civetweb': checked out 'd7ba35bbb649209c66e582d5a0244ba988a15159'
Submodule path '3rdparty/googletest': checked out 'e2239ee6043f73722e7aa812a459f54a28552929'
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Performing Test HAVE_CXX_ATOMICS_WITHOUT_LIB
-- Performing Test HAVE_CXX_ATOMICS_WITHOUT_LIB - Success
-- Could NOT find benchmark (missing: benchmark_DIR)
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
CMake Error at util/CMakeLists.txt:1 (add_library):
  add_library INTERFACE library requires no source arguments.


CMake Error at util/CMakeLists.txt:5 (add_library):
  add_library cannot create ALIAS target "prometheus-cpp::util" because
  target "util" does not already exist.


CMake Error at util/CMakeLists.txt:7 (target_compile_features):
  Cannot specify compile features for target "util" which is not built by
  this project.


CMake Error at util/CMakeLists.txt:12 (target_include_directories):
  Cannot specify include directories for target "util" which is not built by
  this project.


CMake Error at util/CMakeLists.txt:17 (set_target_properties):
  set_target_properties Can not find target to add properties to: util


CMake Error at util/CMakeLists.txt:22 (install):
  install TARGETS given target "util" which does not exist.
```

This error occurs when cloning from the current prometheus-cpp master branch.
When using the latest version `v1.1.0` this problem is not occurring.
So I changed the corresponding git pull command in the dockerfile with `--branch v1.1.0`